### PR TITLE
Correct issues with package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
+  "name": "justdeleteme",
+  "version": "1.0.0",
   "dependencies": {
     "del": "*",
     "gulp-rename": "*",
     "gulp-swig": "*",
-    "gulp-data": "*"
+    "gulp-data": "*",
+    "gulp-ga": "*"
   },
   "devDependencies": {
     "gulp-jsonlint": "^1.1.0"


### PR DESCRIPTION
`gulp-ga` is not listed in the package dependencies but it is required to run the gulp tasks. I also added the name and version because they were missing. Assumed version 1.0.0 since this is a fork of an already in-production project.