### PR TITLE
Update sites.json

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -4599,7 +4599,7 @@
         "url": "http://shopify.com/admin/settings/account",
         "difficulty": "easy",
         "notes": "Select 'Please cancel my account'. Choose a reason then select 'close my shopify store'.",
-        "notes_fr": "Selectionnez supprimer mon compte. Choisissez la raison et cliquez 'close my spotify store'",
+        "notes_fr": "Selectionnez supprimer mon compte. Choisissez la raison et cliquez 'close my shopify store'",
         "notes_it": "Seleziona 'Please cancel my account'. Seleziona un motivo e seleziona 'close my shopify store'.",
         "notes_pt_br": "Selecione 'Please cancel my account'. Escolha um motivo e selecione 'close my shopify store'.",
         "notes_cat": "Seleccioni 'Please cancel my account'. Esculli un motiu i seleccioni 'close my shopify store'.",
@@ -4851,7 +4851,7 @@
 
     {
         "name": "Spotify",
-        "url": "https://support.spotify.com/close/",
+        "url": "http://support.spotify.com/close-account",
         "difficulty": "easy",
         "domains": [
             "spotify.com",


### PR DESCRIPTION
Corrected spelling mistake in French Shopify description.

Changed Spotify URL. The account deletion/closure mechanism is slightly different to http://support.spotify.com/close – while the updated URL (/close-account) triggers an e-mail with a confirmation link that deletes the account, /close just sends an automated e-mail from support queuing the account for deletion which might take several days (in one test case it was never deleted; had to be requested a second time).