### PR TITLE
Fix FireFox scrollTo bug

### DIFF
--- a/docs/assets/js/scripts.js
+++ b/docs/assets/js/scripts.js
@@ -127,12 +127,12 @@ $(function(){
 
     $('.banner').click(function(e) {
         e.preventDefault();
-     $('body').scrollTo('.banner-block');
+     $('body,html').scrollTo('.banner-block');
     });
 
     $('.info').click(function(e) {
         e.preventDefault();
-     $('body').scrollTo('.about');
+     $('body,html').scrollTo('.about');
     });
 
     // create the keys and konami variables


### PR DESCRIPTION
In Firefox, the document overflow is placed at the `<html>` level, so the tag must be included in `scrollTo()` invocations.

Ref: http://stackoverflow.com/a/8149216/540162

Fixes jdm-contrib/justdelete.me#68