### PR TITLE
Remove Hitbox, add Smashcast to sites.json

### DIFF
--- a/docs/ar.html
+++ b/docs/ar.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								صعب
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">شاهد المعلومات...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">معلومات غير متاحة</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	سهل
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">شاهد المعلومات...</a>
 						
 						
 						

--- a/docs/cat.html
+++ b/docs/cat.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								difícil
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">mostrar informació</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">No hi ha informació disponible</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	fàcil
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">mostrar informació</a>
 						
 						
 						

--- a/docs/de.html
+++ b/docs/de.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								schwer
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">zeige Info...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">Keine Information verfügbar.</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	leicht
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">zeige Info...</a>
 						
 						
 						

--- a/docs/es.html
+++ b/docs/es.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								difícil
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">mostrar información</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">No hay información disponible</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	fácil
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">mostrar información</a>
 						
 						
 						

--- a/docs/fa.html
+++ b/docs/fa.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								سخت
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">نمایش توضیحات...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">اطلاعاتی در دسترس نیست</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	آسان
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">نمایش توضیحات...</a>
 						
 						
 						

--- a/docs/fr.html
+++ b/docs/fr.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								difficile
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">voir les infos...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">Informations non disponibles</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	facile
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">voir les infos...</a>
 						
 						
 						

--- a/docs/id.html
+++ b/docs/id.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								sulit
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">lihat info...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">Info Tidak Tersedia</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	mudah
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">lihat info...</a>
 						
 						
 						

--- a/docs/index.html
+++ b/docs/index.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								hard
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">show info...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">No Info Available</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	easy
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">show info...</a>
 						
 						
 						

--- a/docs/it.html
+++ b/docs/it.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								difficile
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">mostra informazioni...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">Nessuna Informazione Disponibile</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	facile
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">mostra informazioni...</a>
 						
 						
 						

--- a/docs/nl.html
+++ b/docs/nl.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								moeilijk
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">toon informatie...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">Geen informatie beschikbaar</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	gemakkelijk
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">toon informatie...</a>
 						
 						
 						

--- a/docs/pl.html
+++ b/docs/pl.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								trudne
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">pokaż info...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">Info Niedostępne</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	łatwe
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">pokaż info...</a>
 						
 						
 						

--- a/docs/pt_br.html
+++ b/docs/pt_br.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								difícil
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">exibir informações...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">Nenhuma Informação Disponível</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	fácil
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">exibir informações...</a>
 						
 						
 						

--- a/docs/ro.html
+++ b/docs/ro.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								greu
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">afișează informații...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">Nu avem informații.</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	ușor
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">afișează informații...</a>
 						
 						
 						

--- a/docs/ru.html
+++ b/docs/ru.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								трудно
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">показать информацию...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">Информация недоступна</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	легко
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">показать информацию...</a>
 						
 						
 						

--- a/docs/sk.html
+++ b/docs/sk.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								ťažké
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">ukázať informácie...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">Žiadne informácie</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	ľahké
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">ukázať informácie...</a>
 						
 						
 						

--- a/docs/sr.html
+++ b/docs/sr.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								тешко
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">прикажи податке...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">Нема података</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	лако
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">прикажи податке...</a>
 						
 						
 						

--- a/docs/th.html
+++ b/docs/th.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								ยาก
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">แสดงข้อมูล...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">ไม่มีข้อมูล</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	ง่าย
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">แสดงข้อมูล...</a>
 						
 						
 						

--- a/docs/tr.html
+++ b/docs/tr.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								zor
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">bilgi göster...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">Bilgi Yok</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	basit
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">bilgi göster...</a>
 						
 						
 						

--- a/docs/vi.html
+++ b/docs/vi.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								khó
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">xem thông tin...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">Không có thông tin</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	dễ
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">xem thông tin...</a>
 						
 						
 						

--- a/docs/zh-cn.html
+++ b/docs/zh-cn.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								困难
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">查看信息...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">无可用信息</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	简单
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">查看信息...</a>
 						
 						
 						

--- a/docs/zh-tw.html
+++ b/docs/zh-tw.html
@@ -5269,28 +5269,6 @@
 						
 					</section>
 				
-					<section class="site-block hard">
-						<a class="site-header" href=" http://help.hitbox.tv/customer/portal/emails/new ">
-	                        hitbox
-	                    </a>
-						
-						<p class="site-difficulty">		
-							
-								困難
-							
-	                    </p>
-						
-						
-							<div class="tooltip-content">
-								You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.
-								
-							</div>
-							<a href="#" class="tooltip-toggle contains-info">查看訊息...</a>
-						
-						
-						
-					</section>
-				
 					<section class="site-block impossible">
 						<a class="site-header" href=" http://hol.org.uk/profile.php?view=quithol ">
 	                        HOL Virtual Hogwarts
@@ -10192,6 +10170,28 @@
 						
 						
 							<p class="tooltip-toggle">無可用訊息</p>
+						
+						
+						
+					</section>
+				
+					<section class="site-block easy">
+						<a class="site-header" href=" https://www.smashcast.tv ">
+	                        Smashcast
+	                    </a>
+						
+						<p class="site-difficulty">		
+							
+							  	簡單
+							
+	                    </p>
+						
+						
+							<div class="tooltip-content">
+								Access your user settings page, click the &quot;Delete Account...&quot; link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.
+								
+							</div>
+							<a href="#" class="tooltip-toggle contains-info">查看訊息...</a>
 						
 						
 						

--- a/sites.json
+++ b/sites.json
@@ -2854,16 +2854,6 @@
     },
 
     {
-        "name": "hitbox",
-        "url": "http://help.hitbox.tv/customer/portal/emails/new",
-        "difficulty": "hard",
-        "notes": "You have to send an email to the support team asking for deletion of your account. Your account will be added to a list of accounts for deletion, and it may take some time before it has actually been deleted.",
-        "domains": [
-            "hitbox.tv"
-        ]
-    },
-
-    {
         "name": "HOL Virtual Hogwarts",
         "url": "http://hol.org.uk/profile.php?view=quithol",
         "difficulty": "impossible",
@@ -5454,6 +5444,16 @@
         "difficulty": "hard",
         "domains": [
             "smartrecruiters.com"
+        ]
+    },
+
+    {
+        "name": "Smashcast",
+        "url": "https://www.smashcast.tv",
+        "difficulty": "easy",
+        "notes": "Access your user settings page, click the \"Delete Account...\" link. Check each of the boxes that appear, enter your account password, and complete the captcha to confirm account deletion.",
+        "domains": [
+            "smashcast.tv"
         ]
     },
 


### PR DESCRIPTION
Hitbox.tv redirects to Smashcast.tv as it was merged with Azubu [1],
thus this commit removes the now-outdated account deletion steps for
Hitbox.tv, and adds the steps required to delete an account from
Smashcast.tv.

[1]: https://en.wikipedia.org/wiki/Smashcast.tv#firstHeading