### PR TITLE
Updated quora. Set difficulty to easy

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -4935,8 +4935,8 @@
     {
         "name": "Quora",
         "url": "http://www.quora.com/Quora-product/How-do-I-delete-my-Quora-account",
-        "difficulty": "hard",
-        "notes": "First deactivate your account. Log in, go to 'Settings', 'Privacy', and then 'Deactivate Account'. You can then e-mail privacy@quora.com if you want to completely delete your account.",
+        "difficulty": "easy",
+        "notes": "Log in, go to 'Settings', 'Privacy', and then 'Delete Account'.",
         "domains": [
             "quora.com"
         ]


### PR DESCRIPTION
Quora no longer require users to email support regarding account deletion. They have provided a 'delete' link.