### PR TITLE
Fix Konami code styling

### DIFF
--- a/docs/assets/js/scripts.js
+++ b/docs/assets/js/scripts.js
@@ -162,7 +162,7 @@ $(function(){
             // do something such as:
             (function(){
                 $(".site-block:first").after("<section class=\"site-block impossible\"><a class=\"site-header\" href=\"http://www.nsa.gov/\">NSA</a><p class=\"site-difficulty\">Difficulty: impossible</p><p class=\"tooltip-toggle\">No Info Available</p></section>"
-                    +"<section class=\"site-block impossible\"><a class=\"site-header\" href=\"http://www.gchq.gov.uk/Pages/homepage.aspx\">GCHQ</a><p class=\"site-difficulty\">Difficulty: impossible</p><p class=\tooltip-toggle\">No Info Available</p></section>");
+                    +"<section class=\"site-block impossible\"><a class=\"site-header\" href=\"http://www.gchq.gov.uk/Pages/homepage.aspx\">GCHQ</a><p class=\"site-difficulty\">Difficulty: impossible</p><p class=\"tooltip-toggle\">No Info Available</p></section>");
             })();
 
             // and finally clean up the keys array


### PR DESCRIPTION
before:
![before](https://user-images.githubusercontent.com/2199511/36704671-3bea3dd4-1b59-11e8-803d-9ab59e6e0ef6.png)

after:
![after](https://user-images.githubusercontent.com/2199511/36704678-3e4fb63a-1b59-11e8-99ec-c74207987ecd.png)

This doesn't attempt to fix the whitespace-between-boxes alignment issue, only the styling issue.